### PR TITLE
Tweak handling of shell history

### DIFF
--- a/pkg/shell/shell_command.go
+++ b/pkg/shell/shell_command.go
@@ -45,7 +45,7 @@ Crtl+D to exit
 
 			var histories []string
 
-			if _, err := os.Stat(sqlHistoryPath); os.IsExist(err) {
+			if _, err := os.Stat(sqlHistoryPath); err == nil {
 				file, err := os.Open(sqlHistoryPath)
 				if err != nil {
 					golog.Warnf("Unable to open command history. [%s]", err.Error())


### PR DESCRIPTION
Attempt at tweaking the weird behaviour described in #52.

**Notes:**
- I haven't attempted at handling multi-line queries [as described here](https://docs.lenses.io/dev/lenses-cli/#interactive-shell)
- I am a Go newbie, so not totally sure what I am doing here...
