### PR TITLE
Add support for infra/custom alerts routing to channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.3.0
 	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/gokrb5.v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -164,6 +165,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 h1:A7GG7zcGjl3jqAqGPmcNjd/D9hzL95SuoOQAaFNdLU0=
 github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -186,6 +188,7 @@ github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jW
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=

--- a/pkg/alert/payloads.go
+++ b/pkg/alert/payloads.go
@@ -8,6 +8,8 @@ type SettingConditionPayloads struct {
 
 //SettingConditionPayload is the payload for creating alert setttings
 type SettingConditionPayload struct {
-	AlertID   int    `json:"alert" yaml:"alert"`
-	Condition string `json:"condition" yaml:"condition"`
+	AlertID     int      `json:"alert" yaml:"alert"`
+	Condition   string   `json:"condition" yaml:"condition"`
+	ConditionID string   `json:"conditionID,omitempty" yaml:"conditionID"`
+	Channels    []string `json:"channels" yaml:"channels"`
 }

--- a/pkg/api/alert_client.go
+++ b/pkg/api/alert_client.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/landoop/lenses-go/pkg"
+)
+
+// AlertSettingsPayload contains the alert's settings datastructure
+type AlertSettingsPayload struct {
+	AlertID  string   `json:"id,omitempty" yaml:"id"`
+	Enable   bool     `json:"enable" yaml:"enable"`
+	Channels []string `json:"channels" yaml:"channels"`
+}
+
+// AlertSettingsConditionPayload is the payload for creating alert conditions
+type AlertSettingsConditionPayload struct {
+	AlertID     string   `json:"alert" yaml:"alert"`
+	ConditionID string   `json:"conditionID,omitempty" yaml:"conditionID"`
+	Condition   string   `json:"condition" yaml:"condition"`
+	Channels    []string `json:"channels" yaml:"channels"`
+}
+
+// UpdateAlertSettings corresponds to `/api/v1/alerts/settings/{alert_setting_id}`
+func (c *Client) UpdateAlertSettings(alertSettings AlertSettingsPayload) error {
+	path := fmt.Sprintf("%s/%s", pkg.AlertsSettingsPath, alertSettings.AlertID)
+
+	jsonPayload, err := json.Marshal(AlertSettingsPayload{Enable: alertSettings.Enable, Channels: alertSettings.Channels})
+	_, err = c.Do(http.MethodPut, path, contentTypeJSON, jsonPayload)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateAlertSettingsCondition corresponds to `/api/v1/alerts/settings/{alert_setting_id}/condition/{condition_id}`
+func (c *Client) UpdateAlertSettingsCondition(alertID, condition, conditionID string, channels []string) error {
+	path := fmt.Sprintf("%s/%s/condition/%s", pkg.AlertsSettingsPath, alertID, conditionID)
+
+	jsonPayload, err := json.Marshal(AlertSettingsConditionPayload{Condition: condition, Channels: channels})
+	_, err = c.Do(http.MethodPut, path, contentTypeJSON, jsonPayload)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -3300,15 +3300,40 @@ func (c *Client) DeleteQuotaForClient(clientID string, propertiesToRemove ...str
 type (
 	// AlertSetting describes the type of list entry of the `GetAlertSetting` and `CreateOrUpdateAlertSettingCondition`.
 	AlertSetting struct {
-		ID                int               `json:"id" header:"ID,text"`
-		Description       string            `json:"description" header:"Desc"`
-		Category          string            `json:"category" header:"Category"`
-		Enabled           bool              `json:"enabled" header:"Enabled"`
-		IsAvailable       bool              `json:"isAvailable" header:"Available"`
-		Docs              string            `json:"docs,omitempty" header:"Docs"`
-		ConditionTemplate string            `json:"conditionTemplate,omitempty" header:"Cond Tmpl"`
-		ConditionRegex    string            `json:"conditionRegex,omitempty" header:"Cond Regex"`
-		Conditions        map[string]string `json:"conditions,omitempty" header:"Conds"`
+		ID                int                              `json:"id,omitempty" header:"ID,text"`
+		Description       string                           `json:"description,omitempty" header:"Desc"`
+		Category          string                           `json:"category,omitempty" header:"Category"`
+		Enabled           bool                             `json:"enabled,omitempty" header:"Enabled"`
+		IsAvailable       bool                             `json:"isAvailable,omitempty" header:"Available"`
+		Docs              string                           `json:"docs,omitempty"`
+		ConditionTemplate string                           `json:"conditionTemplate,omitempty"`
+		ConditionRegex    string                           `json:"conditionRegex,omitempty"`
+		Conditions        map[string]string                `json:"conditions,omitempty" header:"Conds"`
+		Channels          []AlertChannel                   `json:"channels,omitempty" header:"Chan,count"`
+		ConditionDetails  map[string]AlertConditionDetails `json:"conditionDetails,omitempty"`
+	}
+
+	// AlertChannel contains the payload for the Alert channel's routing information
+	AlertChannel struct {
+		ID           string `json:"id" yaml:"id"`
+		Name         string `json:"name" yaml:"name"`
+		TemplateName string `json:"templateName" yaml:"templateName"`
+	}
+
+	// AlertConditionDsl contains the paylod for the condition's details
+	AlertConditionDsl struct {
+		Group     string `json:"group,omitempty"`
+		Threshold int    `json:"threshold,omitempty"`
+		Topic     string `json:"topic,omitempty"`
+	}
+	// AlertConditionDetails contains the payload for an alert's condition details
+	AlertConditionDetails struct {
+		CreatedAt    string            `json:"createdAt,omitempty"`
+		CreatedBy    string            `json:"createdBy,omitempty"`
+		ModifiedAt   string            `json:"modifiedAt,omitempty"`
+		ModifiedBy   string            `json:"modifiedBy,omitempty"`
+		Channels     []AlertChannel    `json:"channels,omitempty"`
+		ConditionDsl AlertConditionDsl `json:"conditionDsl,omitempty"`
 	}
 
 	// AlertSettings describes the type of list entry of the `GetAlertSettings`.

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -30,4 +30,5 @@ const (
 	ConnectionTemplatesAPIPath = "v1/connection/connection-templates"
 	ConsumersGroupPath         = "api/consumers"
 	ElasticsearchIndexesPath   = "/api/elastic/indexes"
+	AlertsSettingsPath         = "api/v1/alerts/settings"
 )


### PR DESCRIPTION
**Updated commands**:
 - `lenses-cli alert setting` You can now see the updated payload that includes channels information for both infra and custom rules (at different level) e.g.

```
# For infra type of alerts
lenses-cli alert setting --id=1000 --output json --pretty

# For custom type of alerts 
lenses-cli alert setting --id=2000 --output json --pretty
```

 - `lenses-cli alert setting set` mapping to `/api/v1/alerts/settings/{alert_setting_id}`
 - `lenses-cli alert setting condition set` mapping to `/api/v1/alerts/settings/{alert_setting_id}/condition/{condition_id}`

**Usage examples**:

```
# Get an alert's settings 
$ lenses-cli alert setting --id 1000 --output json --pretty

# For infra type of alerts
# Update an alert's settings including the new `channels` parameter, etc.
$ lenses-cli alert setting set \
  --id 1000 \
  --enable=false \
  --channels="143315dd-80bf-4833-a13a-394be06dda87" \
  --channels="f9d6140c-4823-4157-a93c-5147aa0e2f29"
  
# or use a YAML file
$ cat ~/tmp/alerts-cli/alert_sett.yaml
id: 1000
enable: false
channels:
  - "f9d6140c-4823-4157-a93c-5147aa0e2f29"
  - "143315dd-80bf-4833-a13a-394be06dda87"
            
$ lenses-cli alert setting set ~/tmp/alerts-cli/alert_sett.yaml 
```

```
# For custom type of alerts
# Get an alert's settings
$ lenses-cli alert setting --id=2000 --output json --pretty 

# Create a new condition
$ alert setting condition set \
  --alert 2000 \
  --condition="lag >= 69 on group group-2 and topic topic-2"

# Update an existing condition using flags
$ lenses-cli alert setting condition set --alert 2000 \
  --condition="lag >= 95 on group group-1 and topic topic-1" \
  --conditionID="5a6c3951-dfde-478e-8952-8193e62a9a8a" \
  --channels="143315dd-80bf-4833-a13a-394be06dda87" \
  --channels="f9d6140c-4823-4157-a93c-5147aa0e2f29"

# Update an existing condition using YAML file
$ cat ~/tmp/alerts-cli/alert_conds.yaml 
alert: 2000
conditionID: "5a6c3951-dfde-478e-8952-8193e62a9a8a"
condition:
  "lag >= 30 on group schema-registry and topic backblaze_smart"
channels:
  - "143315dd-80bf-4833-a13a-394be06dda87" 
  - "f9d6140c-4823-4157-a93c-5147aa0e2f29"

$ lenses-cli alert setting condition set ~/tmp/alerts-cli/alert_conds.yaml

```